### PR TITLE
Potential fix for code scanning alert no. 39: Untrusted Checkout TOCTOU

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -16,8 +16,8 @@ jobs:
       contents: 'write'
       pull-requests: 'write'
     steps:
-      - name: 'Get branch name'
-        id: get_branch
+      - name: 'Get PR info'
+        id: get_pr
         uses: actions/github-script@v7
         with:
           result-encoding: string
@@ -27,12 +27,15 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.issue.number
             });
-            return pr.data.head.ref;
+            // Set outputs for both branch and sha
+            core.setOutput('branch', pr.data.head.ref);
+            core.setOutput('sha', pr.data.head.sha);
+            return ''; // result not used
 
       - name: 'Checkout'
         uses: actions/checkout@v4
         with:
-          ref: ${{ steps.get_branch.outputs.result }}
+          ref: ${{ steps.get_pr.outputs.sha }}
           fetch-depth: 0
 
       - name: 'Authenticate to Google Cloud'


### PR DESCRIPTION
Potential fix for [https://github.com/daichi213/gcp_poc_oss_llm_project/security/code-scanning/39](https://github.com/daichi213/gcp_poc_oss_llm_project/security/code-scanning/39)

To fix the TOCTOU vulnerability, the workflow should check out the pull request code using an immutable reference: the commit SHA, not the branch name. This ensures that the code being executed is exactly the code that was reviewed and approved, and cannot be changed by force-pushing or updating the branch after approval. 

Specifically, in the "Checkout" step, replace the `ref` input from `${{ steps.get_branch.outputs.result }}` (the branch name) to `${{ github.event.issue.pull_request.head.sha }}` (the commit SHA). However, since the workflow is triggered by an `issue_comment` event, the `github.event.issue.pull_request` object may not be present directly. Instead, you need to fetch the PR details using the GitHub API, as is already done in the "Get branch name" step. You should update this step to return both the branch name and the commit SHA, or add a new step to fetch the SHA, and then use the SHA in the checkout step.

**Required changes:**
- Update the "Get branch name" step to also output the commit SHA.
- Update the "Checkout" step to use the commit SHA as the `ref`.

No new imports or dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
