### PR TITLE
Potential fix for code scanning alert no. 29: Cache Poisoning via caching of untrusted files

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./google_cloud_infra/.terraform
-          key: ${{ runner.os }}-terraform-${{ hashFiles('./google_cloud_infra/.terraform.lock.hcl') }}
+          key: ${{ runner.os }}-terraform-${{ steps.get_branch.outputs.result }}-${{ hashFiles('./google_cloud_infra/.terraform.lock.hcl') }}
 
       - name: 'Terraform Init'
         id: init


### PR DESCRIPTION
Potential fix for [https://github.com/daichi213/gcp_poc_oss_llm_project/security/code-scanning/29](https://github.com/daichi213/gcp_poc_oss_llm_project/security/code-scanning/29)

To fix this cache poisoning risk, the cache key must be scoped so that untrusted branches (e.g., pull requests) cannot poison the cache used by the default branch or other trusted workflows. The best way to do this is to include the pull request number or branch name in the cache key, ensuring that each PR or branch gets its own isolated cache entry. This prevents untrusted code from polluting the cache used by trusted workflows. 

Specifically, in `.github/workflows/terraform-plan.yml`, update the `key` field in the `Cache Terraform providers` step to include a unique identifier for the PR or branch. For example, use `${{ github.event.pull_request.number }}` if available, or `${{ steps.get_branch.outputs.result }}` (the branch name). This ensures that caches are not shared between untrusted and trusted contexts.

No new methods or imports are needed; only the cache key in the workflow YAML needs to be updated.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
